### PR TITLE
Enable IMU and touchpad for the GPD Win Mini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ hhd = "hhd.__main__:main"
 [project.entry-points."hhd.plugins"]
 legion_go = "hhd.device.legion_go:autodetect"
 rog_ally = "hhd.device.rog_ally:autodetect"
-# gpd_win = "hhd.device.gpd.win:autodetect"
+gpd_win = "hhd.device.gpd.win:autodetect"
 powerbuttond = "hhd.plugins.powerbutton:autodetect"
 # display = "hhd.plugins.display:autodetect"
 

--- a/src/hhd/controller/physical/imu.py
+++ b/src/hhd/controller/physical/imu.py
@@ -32,7 +32,7 @@ class DeviceInfo(NamedTuple):
 
 ACCEL_NAMES = ["accel_3d"]
 GYRO_NAMES = ["gyro_3d"]
-IMU_NAMES = ["bmi323-imu"]
+IMU_NAMES = ["bmi323-imu", "BMI0160"]
 
 ACCEL_MAPPINGS: dict[str, tuple[Axis, str | None, float, float | None]] = {
     "accel_x": ("accel_z", "accel", 1, 3),
@@ -74,7 +74,7 @@ def find_sensor(sensors: Sequence[str]):
         with open(name_fn, "r") as f:
             name = f.read().strip()
 
-        if name in sensors:
+        if any(sensor in name for sensor in sensors):
             logger.info(f"Found device '{name}' at\n{sensor_dir}")
             return sensor_dir, name
 

--- a/src/hhd/device/gpd/win/__init__.py
+++ b/src/hhd/device/gpd/win/__init__.py
@@ -8,6 +8,7 @@ from hhd.plugins import (
     HHDPlugin,
     load_relative_yaml,
     get_outputs_config,
+    get_touchpad_config,
 )
 from hhd.plugins.settings import HHDSettings
 
@@ -41,6 +42,12 @@ class GpdWinControllersPlugin(HHDPlugin):
         base["controllers"]["gpd_win"]["children"]["controller_mode"].update(
             get_outputs_config(can_disable=False)
         )
+
+        if self.dmi == "G1617-01":
+            base["controllers"]["gpd_win"]["children"]["touchpad"] = get_touchpad_config()
+        else:
+            del base["controllers"]["gpd_win"]["children"]["touchpad"]
+
         return base
 
     def update(self, conf: Config):
@@ -93,4 +100,4 @@ def autodetect(existing: Sequence[HHDPlugin]) -> Sequence[HHDPlugin]:
         if not name:
             return []
 
-    return [GpdWinControllersPlugin(name, dmi)]
+    return [GpdWinControllersPlugin(dmi, name)]

--- a/src/hhd/device/gpd/win/const.py
+++ b/src/hhd/device/gpd/win/const.py
@@ -1,0 +1,16 @@
+from hhd.controller import Axis, Button, Configuration
+from hhd.controller.physical.evdev import B, to_map
+
+GPD_TOUCHPAD_BUTTON_MAP: dict[int, Button] = to_map(
+    {
+        "touchpad_touch": [B("BTN_TOOL_FINGER")],  # also BTN_TOUCH
+        "touchpad_right": [B("BTN_TOOL_DOUBLETAP")],
+    }
+)
+
+GPD_TOUCHPAD_AXIS_MAP: dict[int, Axis] = to_map(
+    {
+        "touchpad_x": [B("ABS_X")],  # also ABS_MT_POSITION_X
+        "touchpad_y": [B("ABS_Y")],  # also ABS_MT_POSITION_Y
+    }
+)

--- a/src/hhd/device/gpd/win/controllers.yml
+++ b/src/hhd/device/gpd/win/controllers.yml
@@ -15,6 +15,21 @@ children:
   #
   # Common settings
   #
+  imu:
+    type: bool
+    title: Motion Support
+    hint: >-
+      Enable gyroscope/accelerometer (IMU) support (.3% background CPU use)
+    default: True
+
+  imu_hz:
+    type: discrete
+    title: Motion Hz
+    hint: >-
+      Sets the sampling frequency for the IMU.
+      Check `/sys/bus/iio/devices/iio:device0/in_anglvel_sampling_frequency_available`.
+    options: [50, 100, 200, 400, 800, 1600]
+    default: 400
 
   debug:
     type: bool

--- a/src/hhd/device/gpd/win/controllers.yml
+++ b/src/hhd/device/gpd/win/controllers.yml
@@ -31,6 +31,8 @@ children:
     options: [50, 100, 200, 400, 800, 1600]
     default: 400
 
+  touchpad:
+
   debug:
     type: bool
     title: Debug


### PR DESCRIPTION
IMU requires the [BMI260 kernel module driver](https://github.com/justinweiss/bmi260).

Touchpad works in both virtual and controller mode, but long presses don't seem to have any effect.