### PR TITLE
fix: OverflowError in virual uinput timestamp.

### DIFF
--- a/src/hhd/controller/virtual/uinput/__init__.py
+++ b/src/hhd/controller/virtual/uinput/__init__.py
@@ -166,7 +166,9 @@ class UInputDevice(Consumer, Producer):
         if wrote and self.output_timestamps:
             # We have timestamps with ns accuracy.
             # Evdev expects us accuracy
-            ts = (time.perf_counter_ns() // 1000) % (2**32)
+            # ts should be uint32, but python store it as signed int.
+            # So we make it uint32 in hex.
+            ts = (time.perf_counter_ns() // 1000 + 2**31) % (2**32) - 2**31
             self.dev.write(B("EV_MSC"), B("MSC_TIMESTAMP"), ts)
 
         if wrote:


### PR DESCRIPTION
Recently, I found that controller usually unexpectedly reboot and I got logs below:

```
May 03 02:25:05 ChensHandheld hhd[515]:         GENC  INFO     Emulated controller launched, have fun!
May 03 02:25:06 ChensHandheld hhd[515]:         GENC  ERROR    Received the following error:
May 03 02:25:06 ChensHandheld hhd[515]:                        <class 'OverflowError'>: signed integer is greater than
```

After removing try...catch... sentences, I found it happened in `src/hhd/controller/virtual/uinput/__init__.py` :

```python
ts = (time.perf_counter_ns() // 1000) % (2**32)
self.dev.write(B("EV_MSC"), B("MSC_TIMESTAMP"), ts)
```

with traceback:

```
Exception in thread Thread-2 (plugin_run):
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.12/site-packages/hhd/device/generic/base.py", line 80, in plugin_run
    controller_loop(conf.copy(), should_exit, updated, dconf, emit)
  File "/usr/lib/python3.12/site-packages/hhd/device/generic/base.py", line 198, in controller_loop
    d_volume_btn.consume(evs)
  File "/usr/lib/python3.12/site-packages/hhd/controller/virtual/uinput/__init__.py", line 170, in consume
    self.dev.write(B("EV_MSC"), B("MSC_TIMESTAMP"), ts)
  File "/usr/lib/python3.12/site-packages/evdev/eventio.py", line 85, in wrapper
    return func(*args)
           ^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/evdev/eventio.py", line 137, in write
    _uinput.write(self.fd, etype, code, value)
OverflowError: signed integer is greater than maximum
```

The reason is that the value accepts uint32, but Python only has signed integer. So I make a workaround on it.
Reference: [Kernel Documents](https://www.kernel.org/doc/Documentation/input/event-codes.txt#:~:text=have%20special%20meaning%3A%0A%0A*-,MSC_TIMESTAMP,-%3A%0A%20%20%2D%20Used%20to%20report)