### PR TITLE
Add option for ROG Ally to remap ROG/QAM to L5/R5, with double/triple-tap for original function

### DIFF
--- a/src/hhd/controller/base.py
+++ b/src/hhd/controller/base.py
@@ -578,6 +578,7 @@ class Multiplexer:
         startselect_chord: str = "disabled",
     ) -> None:
         self.swap_guide = swap_guide
+        self.guide_to_paddles = os.environ.get('HHD_GUIDE_TO_PADDLES', False)
         self.trigger = trigger
         self.dpad = dpad
         self.led = led
@@ -974,6 +975,12 @@ class Multiplexer:
                                 if self.swap_guide == "start_is_keyboard":
                                     ev["code"] = "start"
 
+                    if self.guide_to_paddles:
+                        if ev["code"] == "mode":
+                            ev["code"] = "extra_l2"
+                        elif ev["code"] == "share":
+                            ev["code"] = "extra_r2"
+                    
                     if (
                         self.startselect_chord != "disabled" and ev["code"] == "select"
                     ) or (


### PR DESCRIPTION
Tested this with all the combinations of swap guide and guide to paddles on an OG ROG Ally.  It's the only handheld I have, but I implemented it mostly in the multiplexer, so it should be pretty easy to add to other devices.  I added on to the existing multi-tap code for QAM, and added a simple version of it for guide.

Next up, I'm planning on adding an option to the shortcuts section to treat the middle third of the left and right side of the screen as touchpads, probably best used with disabling touchscreen input.  I can either include in this PR or submit it separately.  Let me know if you have an opinion.  For now, I'm planning a separate PR, in a branch that starts from this one.

I'm planning to allow 3 different placement choices.

```
 ________________________________________
|<    swipe        down       region    >|
| 30% top swipe                          |
|________                        ________|
|<  20% >|                      |        |
|        |  trackpad            |        |
| 40%    |< emulation           |        |
|________|  region              |________|
|                                        |
| 30% bottom swipe                       |
|<____swipe_________up________region____>|
 ________________________________________
|<  20% >|<  swipe down region >|        |
|        |  trackpad            |        |
| 40%    |< emulation           |        |
|________|  region              |________|
|                                        |
| 30% top swipe                          |
|........................................|
|                                        |
| 30% bottom swipe                       |
|<____swipe_________up________region____>|
 ________________________________________
|<    swipe        down       region    >|
| 30% top swipe                          |
|........................................|
|                                        |
| 30% bottom swipe                       |
|________                        ________|
|<  20% >|  trackpad            |        |
|        |< emulation           |        |
| 40%    |  region              |        |
|________|<___swipe_up_region__>|________|
```
I'll probably also include an option to only capture the left or right side, and map it to the entire 
If it's not apparent, my main goal here is to be able to use community steam input profiles that were built for the steam deck without missing any features, and many of them heavily feature trackpad menus (at least on the KBM-focused builder games I like).  Using the edge of the screen may not be as ergonomic as the deck, but just having dual trackpads opens up a lot of Steam Input options.