### PR TITLE
install.sh: change file contexes if SELinux is in enforcing mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,12 +40,25 @@ sudo curl https://raw.githubusercontent.com/hhd-dev/hhd/master/usr/lib/systemd/s
 
 # Add hhd to user path
 mkdir -p ~/.local/bin
-ln -s ~/.local/share/hhd/venv/bin/hhd ~/.local/bin/hhd
-ln -s ~/.local/share/hhd/venv/bin/hhd.contrib ~/.local/bin/hhd.contrib
+ln -sf ~/.local/share/hhd/venv/bin/hhd ~/.local/bin/hhd
+ln -sf ~/.local/share/hhd/venv/bin/hhd.contrib ~/.local/bin/hhd.contrib
 
 FINAL_URL='https://api.github.com/repos/hhd-dev/hhd-ui/releases/latest'
 curl -L $(curl -s "${FINAL_URL}" | grep "browser_download_url" | cut -d '"' -f 4) -o $HOME/.local/bin/hhd-ui
 chmod +x $HOME/.local/bin/hhd-ui
+
+if [ -f /sys/fs/selinux/enforce ]; then
+  # The presence of this file means SELinux is loaded in the kernel.
+  # A value of 0 means Permissive, 1 means Enforcing.
+  selinux_enforcing=$(cat /sys/fs/selinux/enforce)
+  if [[ "$selinux_enforcing" != "0" ]]; then
+    echo "SELinux is loaded and in enforcing mode: changing hhd file security contextes:"
+    # Fedora Atomic derived distros (e.g. bazzite-gnome) have /home as a symlink to /var/home
+    user_home_dir=$(readlink -f $HOME)
+    sudo semanage fcontext -a -t bin_t $user_home_dir/.local/share/hhd/venv/bin/'.*'
+    sudo restorecon -Rv $user_home_dir//.local/share/hhd/venv/bin/
+  fi
+fi
 
 # Start service and reboot
 sudo systemctl enable --now hhd_local@$(whoami)


### PR DESCRIPTION
On Fedora derived distros, currently, after running `install.sh`, `sudo systemctl start hhd_local@$(whoami)` would fail.

`journalctl -u hhd_local@$(whoami) would show:

```
hhd_local@<user>.service: Failed at step EXEC spawning /home/<user>/.local/share/hhd/venv/bin/hhd: Permission denied
hhd_local@<user>.service: Main process exited, code=exited, status=203/EXEC
```
See https://serverfault.com/questions/1006417/selinux-blocking-execution-in-systemd-unit

This patch sets the binaries in the hhd python virtual env from
	`system_u:object_r:data_home_t:s0`
to:
	`system_u:object_r:bin_t:s0`

Tested on bazzite-gnome 42 and should work on Fedora.