### PR TITLE
Fix MSI Claw Device Issues

### DIFF
--- a/src/hhd/controller/physical/evdev.py
+++ b/src/hhd/controller/physical/evdev.py
@@ -350,6 +350,12 @@ class GenericGamepadEvdev(Producer, Consumer):
 
     def close(self, exit: bool) -> bool:
         if self.dev:
+            try:
+                if self.grab:
+                    self.dev.ungrab()
+            except Exception as e:
+                logger.warning(f"Failed to ungrab device {self.dev.path}: {e}")
+            
             if self.hidden and exit:
                 unhide_gamepad(self.dev.path, self.hidden)
             self.dev.close()

--- a/src/hhd/device/claw/base.py
+++ b/src/hhd/device/claw/base.py
@@ -410,21 +410,25 @@ def controller_loop(
         btn_map=dconf.get("btn_mapping", MSI_CLAW_MAPPINGS),
     )
 
-    # Mute these so after suspend we do not get stray keypresses
+    # Desktop detectors with dynamic grabbing
     d_kbd_2 = DesktopDetectorEvdev(
         vid=[MSI_CLAW_VID],
         pid=[MSI_CLAW_XINPUT_PID, MSI_CLAW_DINPUT_PID],
         required=False,
-        grab=True,
+        grab=False,  # Start without grabbing, grab dynamically when needed
         capabilities={EC("EV_KEY"): [EC("KEY_ESC")]},
     )
     d_mouse = DesktopDetectorEvdev(
         vid=[MSI_CLAW_VID],
         pid=[MSI_CLAW_XINPUT_PID, MSI_CLAW_DINPUT_PID],
         required=False,
-        grab=True,
+        grab=False,  # Start without grabbing, grab dynamically when needed
         capabilities={EC("EV_KEY"): [EC("BTN_MOUSE")]},
     )
+    
+    # Track grabbing state for desktop detectors
+    d_kbd_2_grabbed = False
+    d_mouse_grabbed = False
 
     kargs = {}
 
@@ -513,6 +517,22 @@ def controller_loop(
             for d in devs:
                 if id(d) in to_run:
                     evs.extend(d.produce(r))
+
+            # Dynamic grabbing for desktop detectors
+            # Only grab when we need to detect desktop events, release when not needed
+            if not d_kbd_2_grabbed and d_kbd_2.dev:
+                try:
+                    d_kbd_2.dev.grab()
+                    d_kbd_2_grabbed = True
+                except Exception:
+                    pass  # Ignore grab failures, continue without grabbing
+            
+            if not d_mouse_grabbed and d_mouse.dev:
+                try:
+                    d_mouse.dev.grab()
+                    d_mouse_grabbed = True
+                except Exception:
+                    pass  # Ignore grab failures, continue without grabbing
 
             # Detect if we are in desktop mode through events
             desktop_mode = d_mouse.desktop or d_kbd_2.desktop

--- a/src/hhd/plugins/powerbutton/const.py
+++ b/src/hhd/plugins/powerbutton/const.py
@@ -84,6 +84,7 @@ SUPPORTED_DEVICES: Sequence[PowerButtonConfig] = [
         "MSI Claw A8",
         "Claw A8 BZ2EM",
         type="only_press",
+        phys=["gpio-keys", "LNXPWRBN", "PNP0C0C"],
     ),
 ]
 


### PR DESCRIPTION
## Fix MSI Claw Device Issues

### Problem
- XInput mode startup failure with "Device or resource busy" error
- Physical devices remained inaccessible (000 permissions) after HHD stops  
- Power button not detected on MSI Claw A8

### Solution
- Add explicit `ungrab()` in `GenericGamepadEvdev.close()` to prevent resource leaks
- Implement dynamic grabbing for desktop detectors with graceful error handling (inspired by ROG Ally implementation)
- Fix `unhide_all()` to trigger udev reload even when device tracking list is empty
- Add `gpio-keys` identifier for MSI Claw A8 power button

Resolves critical usability issues for MSI Claw users including XInput mode startup and proper device cleanup.