### PR TITLE
oxp: enable secondary RGB LED support for hid_v1 protocol

### DIFF
--- a/src/hhd/device/oxp/const.py
+++ b/src/hhd/device/oxp/const.py
@@ -162,7 +162,7 @@ CONFS = {
         "x1": True,
         "rgb_secondary": True,
         "mapping": X1_MAPPING,
-        "protocol": "serial",
+        "protocol": "hid_v1",
         "turbo": False,  # disable turbo takeover so that it can be used for TDP
     },
     "ONEXPLAYER G1 i": {


### PR DESCRIPTION
- Change X1 Air protocol from serial to hid_v1
- Enable secondary LED control in hid_v1 (side=3, 4)
- Fix gen_brightness() to use side parameter correctly