### PR TITLE
Add extra button support for GPD Win5 

### DIFF
--- a/src/hhd/device/gpd/win/__init__.py
+++ b/src/hhd/device/gpd/win/__init__.py
@@ -18,6 +18,7 @@ from hhd.i18n import _
 
 from .const import (
     GPD_WIN_4_8840U_MAPPINGS,
+    GPD_WIN_5_MAPPINGS,
     GPD_WIN_DEFAULT_MAPPINGS,
     GPD_WIN_MAX_2_2023_MAPPINGS,
     GPD_WIN_5_BTN_MAPPINGS,
@@ -42,6 +43,7 @@ GPD_CONFS = {
         "name": "GPD Win 5",
         "hrtimer": True,
         "wincontrols": "v2",
+        "mapping": GPD_WIN_5_MAPPINGS,
         "btn_mapping": GPD_WIN_5_BTN_MAPPINGS,
     },
     "G1617-01": {

--- a/src/hhd/device/gpd/win/const.py
+++ b/src/hhd/device/gpd/win/const.py
@@ -39,6 +39,8 @@ GPD_WIN_MAX_2_2023_MAPPINGS: dict[str, tuple[Axis, str | None, float, float | No
 
 GPD_WIN_4_8840U_MAPPINGS = gen_gyro_state("z", True, "x", False, "y", True)
 
+GPD_WIN_5_MAPPINGS = gen_gyro_state("z", True, "x", False, "y", True)
+
 GPD_WIN_5_BTN_MAPPINGS: dict[int, Button] = {
     B("KEY_VOLUMEUP"): "key_volumeup",
     B("KEY_VOLUMEDOWN"): "key_volumedown",


### PR DESCRIPTION
L4 is mapped by default to LEFTCTRL + LEFTSHIFT + F14, but in WinControls, it only shows LEFTCTRL + LEFTSHIFT, so it can be inferred that F14 is included by default.
R4 is mapped by default to F3 + F15. Similarly, in WinControls, it only shows F3, so it can be inferred that F15 is included by default.