### PR TITLE
Legion go 2 TDP fixes

### DIFF
--- a/src/adjustor/drivers/lenovo/__init__.py
+++ b/src/adjustor/drivers/lenovo/__init__.py
@@ -202,7 +202,19 @@ class LenovoDriverPlugin(HHDPlugin):
         notify_tdp = False
         self.new_mode = None
         if new_tdp:
-            mode = "custom"
+            # For TDP values received from steam, set the appropriate
+            # mode to get a better experience.
+            if self.go_model != "go2":
+                if new_tdp == 8:
+                    mode = "quiet"
+                elif new_tdp == 15:
+                    mode = "balanced"
+                elif new_tdp == self.performance_tdp:
+                    mode = "performance"
+                else:
+                    mode = "custom"
+            else:
+                mode = "custom"
             conf["tdp.lenovo.tdp.mode"] = mode
         elif new_mode:
             mode = new_mode


### PR DESCRIPTION
Removed the profile matching logic that we dont want to use anyway, and corrected the max wattage on go 2