### PR TITLE
feat: detect YaguareteOS as a known distro

### DIFF
--- a/src/hhd/utils.py
+++ b/src/hhd/utils.py
@@ -16,7 +16,7 @@ from hhd.plugins.plugin import (
 
 logger = logging.getLogger(__name__)
 
-DISTRO_NAMES = ("manjaro", "bazzite", "ubuntu", "arch")
+DISTRO_NAMES = ("manjaro", "bazzite", "ubuntu", "arch", "yaguarete")
 GIT_HHD = "git+https://github.com/hhd-dev/hhd"
 HHD_DEV_DIR = "/run/hhd/dev"
 
@@ -35,6 +35,8 @@ def get_distro_color():
             return 28
         case "blood_orange" | "blood_orange_ba":
             return 18
+        case "yaguarete" | "yaguarete_ba":
+            return 16
         case _:
             return 30
 


### PR DESCRIPTION
## Summary

Adds `"yaguarete"` to `DISTRO_NAMES` and a matching hue in `get_distro_color()` so the existing substring scan over `/etc/os-release` detects YaguareteOS and reports it to `hhd-ui`.

YaguareteOS is a Bazzite-derived Fedora Atomic image with Argentine cultural identity (Yaguareté = jaguar in Guaraní). Public since May 2026 with `:stable` ISOs for the deck variant on archive.org. Source: https://github.com/lobinuxsoft/yaguarete_os

`/etc/os-release` `ID` is `yaguarete_os`, which contains the substring `yaguarete` — matches the existing detection logic without any further changes.

## Changes

- `src/hhd/utils.py`:
  - `DISTRO_NAMES` gains `"yaguarete"` (5th tuple entry).
  - `get_distro_color()` gains a `case "yaguarete" | "yaguarete_ba": return 16` matching the project palette (`#FF4500` ≈ hue 16°).

## Companion PR

The theme side ships separately in `hhd-dev/hhd-ui#20`, which adds the YaguareteOS logo + Chakra palette + scrollbar style. Both PRs are independent — UI works against the existing daemon and vice versa — but the full theme only lights up when both ship.

## Test plan

- [ ] Existing distros still detected (manjaro/bazzite/ubuntu/arch matrix unaffected).
- [ ] On a YaguareteOS install: `python -c 'from hhd.utils import get_os; print(get_os())'` returns `"yaguarete"`.
- [ ] On the same install: `get_distro_color()` returns `16`.
- [ ] Smoke on real handheld (OneXFly F1 Pro) post-install YaguareteOS-deck — pending.