### PR TITLE
add Konkr Fit (AYANEO sub-brand) controller support

### DIFF
--- a/src/hhd/device/ayaneo/base.py
+++ b/src/hhd/device/ayaneo/base.py
@@ -509,13 +509,19 @@ def controller_loop(
     d_timer = HrtimerTrigger(conf["imu_hz"].to(int), [HrtimerTrigger.IMU_NAMES])
 
     # Inputs
+    # By default the gamepad's BTN_MODE is repurposed as the QAM/overlay
+    # button (share). On devices where it is the main "guide" button (e.g.
+    # Konkr Fit), keep it as the XBOX default (mode) so it opens Steam.
+    xinput_btn_map = {**XBOX_BUTTON_MAP}
+    if not dconf.get("mode_is_guide", False):
+        xinput_btn_map[EC("BTN_MODE")] = "share"
     d_xinput = GenericGamepadEvdev(
         vid=[GAMEPAD_VID],
         pid=[GAMEPAD_PID],
         capabilities={EC("EV_KEY"): [EC("BTN_A")]},
         required=True,
         hide=True,
-        btn_map={**XBOX_BUTTON_MAP, EC("BTN_MODE"): "share"},
+        btn_map=xinput_btn_map,
     )
 
     d_kbd_1 = GenericGamepadEvdev(

--- a/src/hhd/device/ayaneo/const.py
+++ b/src/hhd/device/ayaneo/const.py
@@ -27,6 +27,15 @@ CONFS = {
         "rgb": True,
         **AYA_DEFAULT_CONF,
     },
+    # Konkr (Ayaneo sub-brand). Same controller hw as AYANEO 3
+    # (1c4f:0002 composite + 045e:028e gamepad) but no detachable
+    # modules (no ayaneo-ec EC interface), dual back paddles.
+    "KONKR FIT": {
+        "name": "KONKR FIT",
+        "extra_buttons": "dual",
+        "rgb": True,
+        **AYA_DEFAULT_CONF,
+    },
 }
 
 AYA3_INIT = [

--- a/src/hhd/device/ayaneo/const.py
+++ b/src/hhd/device/ayaneo/const.py
@@ -29,10 +29,13 @@ CONFS = {
     },
     # Konkr (Ayaneo sub-brand). Same controller hw as AYANEO 3
     # (1c4f:0002 composite + 045e:028e gamepad) but no detachable
-    # modules (no ayaneo-ec EC interface), dual back paddles.
+    # modules (no ayaneo-ec EC interface). Four extra buttons (two rear
+    # paddles + LC/RC) and BTN_MODE is the main button, so it acts as the
+    # guide/Steam button rather than the QAM/overlay button.
     "KONKR FIT": {
         "name": "KONKR FIT",
-        "extra_buttons": "dual",
+        "extra_buttons": "quad",
+        "mode_is_guide": True,
         "rgb": True,
         **AYA_DEFAULT_CONF,
     },


### PR DESCRIPTION
  ## Add AYANEO Konkr Fit controller support

  The AYANEO Konkr Fit (HX470) is a new handheld under AYANEO's "KONKR" sub-brand. It uses the same controller hardware as the AYANEO 3 (`1c4f:0002` AYANEO composite + `045e:028e` Xbox gamepad), but reports DMI `product_name` = `KONKR FIT` / `sys_vendor` = `KONKR`, so
  `autodetect` doesn't match it and no controller plugin loads.

  This adds a `CONFS` entry for it. Differences from the AYANEO 3:

  - **No detachable controller modules** (no `ayaneo-ec` EC interface) → `magic_modules` omitted.
  - **Four extra buttons** → `extra_buttons: "quad"`:
    - two rear paddles → `KEY_L` / `KEY_R` → `extra_l1` / `extra_r1`
    - two grip buttons (LC/RC) → `KEY_F21` / `KEY_F22` → `extra_l2` / `extra_r2`

    All four already exist in the driver's `btn_map`, so no input-mapping change was needed.
  - **Guide button**: the Konkr's main system button is the gamepad `BTN_MODE`. By default the AyaNeo driver remaps `BTN_MODE` → `share` (which opens the HHD overlay/QAM). On the Konkr it should open Steam, so a new opt-in `mode_is_guide` dconf flag keeps `BTN_MODE` as
  the XBOX default (`mode` / guide). The flag defaults to `False`, so **AYANEO 3 and all other devices are unchanged**.

  ### Testing

  Tested on a Konkr Fit running Bazzite:

  - ✅ Device is autodetected (`ayaneo_controllers@'KONKR FIT'`)
  - ✅ Controller, gyro, and RGB lighting work
  - ✅ All four extra buttons register (rear paddles + LC/RC)
  - ✅ The main `BTN_MODE` button opens Steam (guide) instead of the overlay

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
