### PR TITLE
Use importlib.metadata for plugin discovery instead of pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
   "evdev>=1.6.1",
   "PyYAML>=6.0.1",
   "rich>=13.5.2",
-  "setuptools>=65.5.0",
   "python-xlib>=0.33",
   "pyserial>=3.5",
   "pyroute2>=0.7.3",

--- a/src/hhd/__main__.py
+++ b/src/hhd/__main__.py
@@ -13,7 +13,7 @@ from threading import RLock
 from time import sleep
 from typing import Callable, Sequence
 
-import pkg_resources
+from importlib.metadata import entry_points
 
 from .logging import set_log_plugin, setup_logger, update_log_plugins
 from .plugins import (
@@ -232,7 +232,7 @@ def main():
 
         detector_names = []
         whitelist = PLUGIN_WHITELIST.split(",") if PLUGIN_WHITELIST else []
-        for autodetect in pkg_resources.iter_entry_points("hhd.plugins"):
+        for autodetect in entry_points(group="hhd.plugins"):
             name = autodetect.name
             detector_names.append(name)
             if name in blacklist:
@@ -241,7 +241,7 @@ def main():
                 logger.info(f"Skipping provider '{name}' due to whitelist.")
                 continue
 
-            detectors[autodetect.name] = autodetect.resolve()
+            detectors[autodetect.name] = autodetect.load()
 
         # Save new blacklist file
         save_blacklist_yaml(blacklist_fn, detector_names, blacklist)
@@ -290,8 +290,8 @@ def main():
 
         # Load locales
         locales = []
-        for register in pkg_resources.iter_entry_points("hhd.i18n"):
-            locales.extend(register.resolve()())
+        for register in entry_points(group="hhd.i18n"):
+            locales.extend(register.load()())
         locales.sort(key=lambda x: x["priority"], reverse=True)
 
         if locales:


### PR DESCRIPTION
Replace `pkg_resources` (from setuptools) with the standard-library `importlib.metadata` for enumerating the `hhd.plugins` and `hhd.i18n` entry points.

### Why

`pkg_resources` is provided by setuptools, which **removed the module in setuptools 81**. On distros that now ship setuptools >= 81 (e.g. current Arch / CachyOS on Python 3.14), `import pkg_resources` raises `ModuleNotFoundError` and hhd fails to start — the systemd unit crash-loops:

```
File ".../hhd/__main__.py", line 16, in <module>
    import pkg_resources
ModuleNotFoundError: No module named "pkg_resources"
```

This is already affecting users on updated CachyOS handheld installs (hhd@<user> stuck in `activating (auto-restart)`).

### Change

`pkg_resources` was only used to enumerate entry points. Migrated to `importlib.metadata.entry_points`, which is already imported elsewhere in this file (for `version`):

- `pkg_resources.iter_entry_points("hhd.plugins")` → `entry_points(group="hhd.plugins")`
- `pkg_resources.iter_entry_points("hhd.i18n")` → `entry_points(group="hhd.i18n")`
- pkg_resources `EntryPoint.resolve()` → importlib `EntryPoint.load()`

`.name` and `.load()` behave the same as before. The selectable `entry_points(group=...)` API is available on Python 3.10+.

### Notes

- No behavior change: same entry-point groups, same resolution.
- Removes the runtime dependency on setuptools / `pkg_resources`.
- Verified on a ROG Ally (CachyOS, Python 3.14, setuptools with pkg_resources absent): hhd starts and all plugins (adjustor/TDP, i18n, controller emulation) load correctly.